### PR TITLE
Update catpuccinmocha.json

### DIFF
--- a/themes-community/catpuccin-mocha/catpuccinmocha.json
+++ b/themes-community/catpuccin-mocha/catpuccinmocha.json
@@ -10,7 +10,7 @@
   "typeLight": "#7f849c",
   "typeSuperlight": "#585b70",
   "typeHyperLight": "#313244",
-  "typeReverse": "#f5e0dc",
+  "typeReverse": "#45475a",
   "accent1Main": "#cba6f7",
   "accent1Secondary": "#f38ba8",
   "accent1Tertiary": "#fab387",


### PR DESCRIPTION
Change the color of typeReverse to #45475a for better contrast and readability. The original color #f5e0dc makes the text unreadable on pills.

## Before - bad contrast
<img width="1544" height="1736" alt="CleanShot-Microsoft Edge-2025-09-09 at 13 24 59@2x" src="https://github.com/user-attachments/assets/19bd5dca-a108-4012-b16a-3606d5125f98" />

## After - good contrast
<img width="1544" height="1736" alt="CleanShot-Microsoft Edge-2025-09-09 at 13 25 40@2x" src="https://github.com/user-attachments/assets/20a9dd3c-8256-40a5-8da6-ea8edd851617" />
