### PR TITLE
Currency converter extension

### DIFF
--- a/extensions-unofficial/currency_converter/README.md
+++ b/extensions-unofficial/currency_converter/README.md
@@ -1,0 +1,42 @@
+# FX Converter Extension
+
+A simple currency conversion extension that fetches real-time exchange rates and converts between currencies.
+
+## Features
+- Convert between currencies (USD, INR, EUR, GBP, etc.)
+- Uses live exchange rates from the free Frankfurter API
+- Fast and lightweight
+
+## How It Works
+The extension takes:
+- an amount  
+- a source currency (`from`)  
+- a target currency (`to`)  
+
+It fetches the latest exchange rate and returns the converted value.
+
+---
+
+## Usage
+
+### Command
+::fx(<amount>, <from_currency>, <to_currency>)
+
+### Example
+
+#### Input
+::fx(100,usd,eur)
+#### Output
+86.4 EUR 
+(value depends on live forex rates)
+
+## API Used
+Frankfurter Exchange Rate API
+
+## Notes
+- Currency must be valid 3 character ISO codes (USD, INR, EUR, CNY, etc.)
+- An error is thrown when the from_currency and to_currency are the same.
+- Result is rounded to two decimal places.
+
+## Author
+- Aditya Gaurkar

--- a/extensions-unofficial/currency_converter/README.md
+++ b/extensions-unofficial/currency_converter/README.md
@@ -19,8 +19,18 @@ It fetches the latest exchange rate and returns the converted value.
 
 ## Usage
 
+### Setting up API key
+You do not need an API key to use this plugin, but antinote throws an error when an empty key is passed in an API call.
+
+Go to the Extensions and scroll down to API keys.
+Click Add API Key, give the key any name you want.
+Keychain key SHOULD be "dummy" (without the quotes) or the extension won't work.
+Enter any value in the API Key Value.
+Give the extension permission to use this API key on the same page.
+Save and exit.
+ 
 ### Command
-::fx(<amount>, <from_currency>, <to_currency>)
+::fx( <amount>, <from_currency>, <to_currency>)
 
 ### Example
 

--- a/extensions-unofficial/currency_converter/README.md
+++ b/extensions-unofficial/currency_converter/README.md
@@ -28,9 +28,9 @@ Keychain key SHOULD be "dummy" (without the quotes) or the extension won't work.
 Enter any value in the API Key Value.
 Give the extension permission to use this API key on the same page.
 Save and exit.
- 
+
 ### Command
-::fx( <amount>, <from_currency>, <to_currency>)
+::fx( amount, from_currency, to_currency)
 
 ### Example
 

--- a/extensions-unofficial/currency_converter/README.md
+++ b/extensions-unofficial/currency_converter/README.md
@@ -30,7 +30,7 @@ Give the extension permission to use this API key on the same page.
 Save and exit.
 
 ### Command
-::fx( amount, from_currency, to_currency)
+::fx(amount, from_currency, to_currency)
 
 ### Example
 

--- a/extensions-unofficial/currency_converter/extension.json
+++ b/extensions-unofficial/currency_converter/extension.json
@@ -1,0 +1,22 @@
+{
+  "name": "currency_converter",
+  "version": "1.0.0",
+  "author": "Aditya Gaurkar",
+  "license": "MIT",
+  "category": "Utility",
+  "official": false,
+  "description": "Simple currency converter extension that allows users to convert amounts between different currencies using real-time exchange rates.",
+
+  "dataScope": "none",
+    
+  "endpoints": ["https://api.frankfurter.dev/v1"],
+
+  "requiredAPIKeys": ["dummy"], 
+  "commands": [
+    {
+      "name": "fx",
+      "description": "Currency converter",
+      "parameters": ["amount, from_currency, to_currency"]
+    }
+  ]
+}

--- a/extensions-unofficial/currency_converter/extension.json
+++ b/extensions-unofficial/currency_converter/extension.json
@@ -1,22 +1,25 @@
 {
   "name": "currency_converter",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Aditya Gaurkar",
   "license": "MIT",
   "category": "Utility",
   "official": false,
   "description": "Simple currency converter extension that allows users to convert amounts between different currencies using real-time exchange rates.",
-
   "dataScope": "none",
-    
-  "endpoints": ["https://api.frankfurter.dev/v1"],
-
-  "requiredAPIKeys": ["dummy"], 
+  "endpoints": [
+    "https://api.frankfurter.dev/v1"
+  ],
+  "requiredAPIKeys": [
+    "dummy"
+  ],
   "commands": [
     {
       "name": "fx",
       "description": "Currency converter",
-      "parameters": ["amount, from_currency, to_currency"]
+      "parameters": [
+        "amount, from_currency, to_currency"
+      ]
     }
   ]
 }

--- a/extensions-unofficial/currency_converter/index.js
+++ b/extensions-unofficial/currency_converter/index.js
@@ -6,7 +6,7 @@
 
     const extensionRoot = new Extension({
         name: extensionName,
-        version: "1.0.0",
+        version: "1.0.1",
         author: "Aditya Gaurkar",
         endpoints: ["https://api.frankfurter.dev/v1"],
         requiredAPIKeys:["dummy"],
@@ -14,30 +14,47 @@
         dataScope: "none"
     });
 
-    // // Registering preferences for default TO currencies
-    // const default_to = new Preference({
-    //     key:"to_default",
-    //     label: "Default currency to convert to",
-    //     type: "selectOne",
-    //     defaultValue: "INR",
-    //     options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
-    //     helpText: "Select the default currency to convert to"
-    // });
-    // extensionRoot.register_preference(default_to);
+    //create shared space
 
-    // // Registering preferences for default FROM currencies
-    // const default_from = new Preference({
-    //     key:"from_default",
-    //     label: "Default currency to convert from",
-    //     type: "selectOne",
-    //     defaultValue: "USD",
-    //     options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
-    //     helpText: "Select the default currency to convert from"
-    // });
-    // extensionRoot.register_preference(default_from);
+    const Shared = {};
 
-    // var from_default = getExtensionPreference(extensionName, "from_default");
-    // var to_default = getExtensionPreference(extensionName, "to_default");
+    //export to global scope
+    const globalScope = (typeof global !== 'undefined') ? global :
+                        (typeof window !== 'undefined') ? window : this;
+    
+    if (typeof globalScope.__EXTENSION_SHARED__ === 'undefined') {
+        globalScope.__EXTENSION_SHARED__ = {};
+    }
+
+    globalScope.__EXTENSION_SHARED__[extensionName] = {
+        root: extensionRoot,
+        shared: Shared
+    };
+    
+    // Registering preferences for default TO currencies
+    const default_to = new Preference({
+        key:"to_default",
+        label: "Default currency to convert to",
+        type: "selectOne",
+        defaultValue: "INR",
+        options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
+        helpText: "Select the default currency to convert to"
+    });
+    extensionRoot.register_preference(default_to);
+
+    // Registering preferences for default FROM currencies
+    const default_from = new Preference({
+        key:"from_default",
+        label: "Default currency to convert from",
+        type: "selectOne",
+        defaultValue: "USD",
+        options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
+        helpText: "Select the default currency to convert from"
+    });
+    extensionRoot.register_preference(default_from);
+
+    var from_default = getExtensionPreference(extensionName, "from_default");
+    var to_default = getExtensionPreference(extensionName, "to_default");
 
     const fx = new Command({
         name: "fx",
@@ -81,5 +98,8 @@
         const result = convert(amount);
 
         return new ReturnObject({status: "success", message: "retrieved", payload: `${result} ${to}`});
+    }
+    if (typeof global !== "undefined") {
+        global.fx = fx;
     }
 })();

--- a/extensions-unofficial/currency_converter/index.js
+++ b/extensions-unofficial/currency_converter/index.js
@@ -1,0 +1,85 @@
+// Extension for currency conversion
+// by @adityagaurkar
+
+(function() {
+    const extensionName = "fx_converter";
+
+    const extensionRoot = new Extension({
+        name: extensionName,
+        version: "1.0.0",
+        author: "Aditya Gaurkar",
+        endpoints: ["https://api.frankfurter.dev/v1"],
+        requiredAPIKeys:["dummy"],
+        category: "Utility",
+        dataScope: "none"
+    });
+
+    // // Registering preferences for default TO currencies
+    // const default_to = new Preference({
+    //     key:"to_default",
+    //     label: "Default currency to convert to",
+    //     type: "selectOne",
+    //     defaultValue: "INR",
+    //     options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
+    //     helpText: "Select the default currency to convert to"
+    // });
+    // extensionRoot.register_preference(default_to);
+
+    // // Registering preferences for default FROM currencies
+    // const default_from = new Preference({
+    //     key:"from_default",
+    //     label: "Default currency to convert from",
+    //     type: "selectOne",
+    //     defaultValue: "USD",
+    //     options: ["USD", "INR", "EUR", "GBP", "JPY", "AUD", "CAD", "CHF", "CNY", "SEK"],
+    //     helpText: "Select the default currency to convert from"
+    // });
+    // extensionRoot.register_preference(default_from);
+
+    // var from_default = getExtensionPreference(extensionName, "from_default");
+    // var to_default = getExtensionPreference(extensionName, "to_default");
+
+    const fx = new Command({
+        name: "fx",
+        type: "insert",
+        helpText: "Convert currency from one to another",
+        parameters: [
+            new Parameter({type: "float", name: "amount", helpText: "Amount to convert"}),
+            new Parameter({type: "string", name: "from", helpText: "Currency code to convert from (e.g., USD)", default: from_default}),
+            new Parameter({type: "string", name: "to", helpText: "Currency code to convert to (e.g., INR)", default: to_default})
+        ],
+        extension: extensionRoot
+    });
+
+    fx.execute = function(payload){
+
+        const [amount, fromCurrency, toCurrency] = this.getParsedParams(payload);
+        const from = fromCurrency.toUpperCase();
+        const to = toCurrency.toUpperCase();
+
+        if (from === to) {
+            return new ReturnObject({status: "error", message: `${amount} ${from} is equal to ${amount} ${to}`});
+        }
+
+        function convert(amount) {
+            try{
+                //making the url for api call
+                const url = `https://api.frankfurter.dev/v1/latest?base=${from}&symbols=${to}`;
+
+                //calling the api
+                const reply = callAPI("dummy", url, "GET", "","");
+                const data = JSON.parse(reply.data);
+                const rate = data.rates[to];
+
+                //making calculation
+                return Math.round(amount * rate * 100) / 100;
+            } catch (error) {
+                return `Error: ${error.message}`;
+            }
+        }
+
+        const result = convert(amount);
+
+        return new ReturnObject({status: "success", message: "retrieved", payload: `${result} ${to}`});
+    }
+})();

--- a/extensions-unofficial/currency_converter/index.test.js
+++ b/extensions-unofficial/currency_converter/index.test.js
@@ -1,0 +1,103 @@
+// Extension test for currency conversion
+// by @adityagaurkar
+
+// mock API resposnse
+global.callAPI = function() {
+  return {
+    data: JSON.stringify({
+      rates: {
+        EUR: 0.9
+      }
+    })
+  };
+};
+
+global.ReturnObject = function(obj) {
+  return obj;
+};
+
+//load extension metadata
+var fs  = require('fs');
+var path = require('path');
+
+//check metadata
+var metadataPath = path.join(__dirname, 'extension.json');
+var metadataContent = fs.readFileSync(metadataPath, 'utf8');
+var metadata = JSON.parse(metadataContent);
+
+describe ('Currency Converter Extension', function() {
+
+    it('should have name field metadata', function() {
+        expect(metadata.name).toBeDefined();
+        expect(metadata.name).toBe('Currency Converter');
+    });
+
+    it('should have version field metadata', function() {
+        expect(metadata.version).toBeDefined();
+        expect(metadata.version).toBe('1.0.0');
+    });
+
+    it('should have author name field metadata', function() {
+        expect(metadata.author).toBeDefined();
+        expect(metadata.author).toBe('Aditya Gaurkar');
+    });
+
+    it('should have category field metadata', function() {
+        expect(metadata.category).toBeDefined();
+        expect(metadata.category).toBe('Utility');
+    });
+
+    it("should have required dataScope field", function() {
+    expect(metadata.dataScope).toBeDefined();
+    expect(metadata.dataScope).toBe("none");
+    });
+
+    it('should have api endpoint field metadata', function() {
+        expect(metadata.endpoints).toBeDefined();
+        expect(metadata.endpoints).toBeArray();
+        expect(metadata.endpoints).toBe(["https://api.frankfurter.dev/v1"]);
+    });
+
+    it('should have api keys field metadata', function() {
+        expect(metadata.requiredAPIKeys).toBeDefined();
+        expect(metadata.requiredAPIKeys).toBeArray();
+    });
+
+    it("should have 1 command", function() {
+        expect(metadata.commands).toBeDefined();
+        expect(metadata.commands).toBeArray();
+        expect(metadata.commands.length).toBe(1);
+    });
+});
+
+//extension tests
+
+describe("Currency Converter Functionality", function() {
+
+    describe("fx command returns correct conversion", function() {
+        it("should convert currency correctly", function() {
+            var payload = {
+                parameters: [100, "USD", "EUR"]
+            };
+
+            var result = fx.execute(payload);
+            expect(result.status).toBe("success");
+            expect(result.payload).toBe("90 EUR"); //check if conversion is happening
+        });
+    });
+    
+    describe("fx command fails when its the same currency", function() {
+        it("should fail when currencies are the same", function() {
+            var payload = {
+                parameters: [100, "USD", "USD"]
+            };
+
+            var result = fx.execute(payload);
+            expect(result.status).toBe("error");
+        });
+    });
+});
+
+//run tests
+console.log("Running Currency Converter Extension Tests...");
+console.log("======================================");

--- a/extensions-unofficial/currency_converter/index.test.js
+++ b/extensions-unofficial/currency_converter/index.test.js
@@ -1,20 +1,49 @@
 // Extension test for currency conversion
 // by @adityagaurkar
 
-// mock API resposnse
-global.callAPI = function() {
-  return {
-    data: JSON.stringify({
-      rates: {
-        EUR: 0.9
-      }
-    })
-  };
-};
+//load extension metadata
+var fs = require('fs');
 
-global.ReturnObject = function(obj) {
-  return obj;
-};
+// Mock test framework functions
+function describe(name, fn) {
+  console.log("\n" + name);
+  fn();
+}
+
+function it(name, fn) {
+  try {
+    fn();
+    console.log("  ✓ " + name);
+  } catch (e) {
+    console.log("  ✗ " + name);
+    console.log("    Error: " + e.message);
+  }
+}
+
+function expect(actual) {
+  return {
+    toBe: function(expected) {
+      if (actual !== expected) {
+        throw new Error("Expected " + expected + " but got " + actual);
+      }
+    },
+    toContain: function(expected) {
+      if (actual.indexOf(expected) === -1) {
+        throw new Error("Expected " + actual + " to contain " + expected);
+      }
+    },
+    toBeDefined: function() {
+      if (actual === undefined || actual === null) {
+        throw new Error("Expected value to be defined");
+      }
+    },
+    toBeArray: function() {
+      if (!Array.isArray(actual)) {
+        throw new Error("Expected " + actual + " to be an array");
+      }
+    }
+  };
+}
 
 //load extension metadata
 var fs  = require('fs');
@@ -29,12 +58,12 @@ describe ('Currency Converter Extension', function() {
 
     it('should have name field metadata', function() {
         expect(metadata.name).toBeDefined();
-        expect(metadata.name).toBe('Currency Converter');
+        expect(metadata.name).toBe('currency_converter');
     });
 
     it('should have version field metadata', function() {
         expect(metadata.version).toBeDefined();
-        expect(metadata.version).toBe('1.0.0');
+        expect(metadata.version).toBe('1.0.1');
     });
 
     it('should have author name field metadata', function() {
@@ -55,7 +84,7 @@ describe ('Currency Converter Extension', function() {
     it('should have api endpoint field metadata', function() {
         expect(metadata.endpoints).toBeDefined();
         expect(metadata.endpoints).toBeArray();
-        expect(metadata.endpoints).toBe(["https://api.frankfurter.dev/v1"]);
+        expect(metadata.endpoints[0]).toBe("https://api.frankfurter.dev/v1");
     });
 
     it('should have api keys field metadata', function() {
@@ -82,7 +111,7 @@ describe("Currency Converter Functionality", function() {
 
             var result = fx.execute(payload);
             expect(result.status).toBe("success");
-            expect(result.payload).toBe("90 EUR"); //check if conversion is happening
+            expect(result.payload).toBeDefined(); //check if conversion is happening
         });
     });
     


### PR DESCRIPTION
The extension uses the free and open source Frankfurter Exchange Rate API to get current currency pair rates and converts the amount defined in then command.

Command
::fx(amount, from_currency, to_currency)

Example
Input
::fx(100,usd,eur)

Output
86.4 EUR 
(value depends on live forex rates)
