### PR TITLE
added a simple inline latex extension

### DIFF
--- a/extensions-unofficial/latex/README.md
+++ b/extensions-unofficial/latex/README.md
@@ -5,7 +5,7 @@ A utility extension to easily work with LaTeX syntax in your Antinote notes.
 ## Commands
 
 ### `::latex(expression)`
-Formats a single math expression into block LaTeX math delimiters `$$expression$$`.
+Translates a LaTeX math expression into Unicode characters directly on the line.
 
 #### Example
 **Before:**
@@ -14,8 +14,18 @@ Formats a single math expression into block LaTeX math delimiters `$$expression$
 ```
 
 **After execution:**
-```latex
-$$3x + 5 = 12$$
+```text
+3x + 5 = 12
+```
+
+**Before:**
+```text
+::latex(\forall x \exists \delta)
+```
+
+**After execution:**
+```text
+∀ x ∃ δ
 ```
 
 ---

--- a/extensions-unofficial/latex/README.md
+++ b/extensions-unofficial/latex/README.md
@@ -31,31 +31,33 @@ Translates a LaTeX math expression into Unicode characters directly on the line.
 ---
 
 ### `::latex_note`
-Searches the entire note for LaTeX formatting (`$$` and `$`). If found, it toggles it off (converting them back to `[content]`). If not found, it toggles it on (converting `[content]` to `$content$`, or wrapping the entire note in `$$ ... $$` if no brackets exist).
+Searches the entire note for LaTeX expressions wrapped in math delimiters (`$$ ... $$`, `$ ... $`, or `[ ... ]`) and translates them into inline Unicode characters, stripping the delimiters. If no delimiters are found, it translates the entire note. This is a one-way formatting operation.
 
-#### Example (Inline Toggle On)
+#### Example (With Delimiters)
 **Before:**
 ```text
 The Pythagorean theorem states that [a^2 + b^2 = c^2], where [c] is the hypotenuse.
 ```
 
-**After `::latex_note`:**
+**After execution:**
 ```text
-The Pythagorean theorem states that $a^2 + b^2 = c^2$, where $c$ is the hypotenuse.
+The Pythagorean theorem states that a² + b² = c², where c is the hypotenuse.
 ```
 
-#### Example (Block Toggle On)
 **Before:**
 ```text
+$$
 x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+$$
 ```
 
-**After `::latex_note`:**
-```latex
-$$
-x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
-$$
+**After execution:**
+```text
+x = ( -b ± √(b² - 4ac) )/(2a)
 ```
+
+#### Example (No Delimiters)
+If no delimiters are present, the command translates any LaTeX elements across the entire note directly.
 
 ## Installation
 

--- a/extensions-unofficial/latex/README.md
+++ b/extensions-unofficial/latex/README.md
@@ -1,0 +1,56 @@
+# LaTeX Extension for Antinote
+
+A utility extension to easily work with LaTeX syntax in your Antinote notes.
+
+## Commands
+
+### `::latex(expression)`
+Formats a single math expression into block LaTeX math delimiters `$$expression$$`.
+
+#### Example
+**Before:**
+```text
+::latex(3x + 5 = 12)
+```
+
+**After execution:**
+```latex
+$$3x + 5 = 12$$
+```
+
+---
+
+### `::latex_note`
+Searches the entire note for LaTeX formatting (`$$` and `$`). If found, it toggles it off (converting them back to `[content]`). If not found, it toggles it on (converting `[content]` to `$content$`, or wrapping the entire note in `$$ ... $$` if no brackets exist).
+
+#### Example (Inline Toggle On)
+**Before:**
+```text
+The Pythagorean theorem states that [a^2 + b^2 = c^2], where [c] is the hypotenuse.
+```
+
+**After `::latex_note`:**
+```text
+The Pythagorean theorem states that $a^2 + b^2 = c^2$, where $c$ is the hypotenuse.
+```
+
+#### Example (Block Toggle On)
+**Before:**
+```text
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+```
+
+**After `::latex_note`:**
+```latex
+$$
+x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
+$$
+```
+
+## Installation
+
+To install this extension locally:
+1. In Antinote, open **Settings > Extensions**.
+2. Click **Open Extensions Folder** to open the extensions directory in Finder.
+3. Copy the `latex` folder into that directory.
+4. Go back to Settings and click **Reload Extensions**.

--- a/extensions-unofficial/latex/extension.json
+++ b/extensions-unofficial/latex/extension.json
@@ -1,0 +1,24 @@
+{
+  "name": "latex",
+  "version": "1.0.0",
+  "author": "user",
+  "description": "Easily wrap notes in LaTeX blocks or convert bracketed text to LaTeX math formulas.",
+  "license": "MIT",
+  "category": "Formatting",
+  "dataScope": "full",
+  "endpoints": [],
+  "requiredAPIKeys": [],
+  "commands": [
+    {
+      "name": "latex",
+      "description": "Translate a LaTeX math expression into Unicode characters",
+      "type": "replaceLine"
+    },
+    {
+      "name": "latex_note",
+      "description": "Auto-detect and toggle LaTeX formatting ($$ and $) in the note",
+      "type": "replaceAll"
+    }
+  ],
+  "official": false
+}

--- a/extensions-unofficial/latex/extension.json
+++ b/extensions-unofficial/latex/extension.json
@@ -1,7 +1,7 @@
 {
   "name": "latex",
-  "version": "1.0.1",
-  "author": "user",
+  "version": "1.0.2",
+  "author": "MaybeItsAdam",
   "description": "Easily wrap notes in LaTeX blocks or convert bracketed text to LaTeX math formulas.",
   "license": "MIT",
   "category": "Formatting",
@@ -16,7 +16,7 @@
     },
     {
       "name": "latex_note",
-      "description": "Auto-detect and toggle LaTeX formatting ($$ and $) in the note",
+      "description": "Convert all LaTeX expressions in the note to Unicode math",
       "type": "replaceAll"
     }
   ],

--- a/extensions-unofficial/latex/extension.json
+++ b/extensions-unofficial/latex/extension.json
@@ -1,6 +1,6 @@
 {
   "name": "latex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "user",
   "description": "Easily wrap notes in LaTeX blocks or convert bracketed text to LaTeX math formulas.",
   "license": "MIT",

--- a/extensions-unofficial/latex/index.js
+++ b/extensions-unofficial/latex/index.js
@@ -3,7 +3,7 @@
 
   const extensionRoot = new Extension({
     name: extensionName,
-    version: "1.0.1",
+    version: "1.0.2",
     endpoints: [],
     requiredAPIKeys: [],
     author: "user",
@@ -316,11 +316,11 @@
     name: "latex_note",
     parameters: [],
     type: "replaceAll",
-    helpText: "Auto-detect and toggle LaTeX formatting in the note",
+    helpText: "Convert all LaTeX expressions in the note to Unicode math",
     tutorials: [
       new TutorialCommand({
         command: "latex_note",
-        description: "Toggles LaTeX formatting in the entire note"
+        description: "Formats LaTeX math in the entire note"
       })
     ],
     extension: extensionRoot
@@ -330,60 +330,36 @@
     const fullText = payload.fullText || "";
 
     const hasDoubleDollar = fullText.includes("$$");
-    const hasSingleDollar = fullText.includes("$");
-    const isLaTeXOn = hasDoubleDollar || hasSingleDollar;
+    const hasSingleDollar = /\$([^$\n]+)\$/.test(fullText);
+    const bracketRegex = /\[((?:[^\[\]]|\[[^\[\]]*\])*)\]/g;
+    const hasBrackets = bracketRegex.test(fullText);
+    bracketRegex.lastIndex = 0; // Reset regex index
 
-    let result;
-    if (isLaTeXOn) {
-      // LaTeX is currently ON -> Toggle it OFF
-      const trimmed = fullText.trim();
-      const startsWithDollar = trimmed.startsWith("$$\n") || trimmed.startsWith("$$");
-      const endsWithDollar = trimmed.endsWith("\n$$") || trimmed.endsWith("$$");
+    let result = fullText;
 
-      if (startsWithDollar && endsWithDollar) {
-        // Unwrap block LaTeX note
-        let content = trimmed;
-        if (content.startsWith("$$\n")) {
-          content = content.substring(3);
-        } else if (content.startsWith("$$")) {
-          content = content.substring(2);
-        }
-
-        if (content.endsWith("\n$$")) {
-          content = content.substring(0, content.length - 3);
-        } else if (content.endsWith("$$")) {
-          content = content.substring(0, content.length - 2);
-        }
-        result = content;
-      } else {
-        // Convert block $$content$$ to [content]
-        let temp = fullText.replace(/\$\$(.*?)\$\$/gs, function(match, content) {
-          return "[" + content + "]";
+    if (hasDoubleDollar || hasSingleDollar || hasBrackets) {
+      if (hasDoubleDollar) {
+        result = result.replace(/\$\$([\s\S]*?)\$\$/g, function(match, content) {
+          return parseLatex(content);
         });
-        // Convert inline $content$ to [content]
-        result = temp.replace(/\$([^$\n]+)\$/g, function(match, content) {
-          return "[" + content + "]";
+      }
+      if (hasSingleDollar) {
+        result = result.replace(/\$([^$\n]+)\$/g, function(match, content) {
+          return parseLatex(content);
+        });
+      }
+      if (hasBrackets) {
+        result = result.replace(bracketRegex, function(match, content) {
+          return parseLatex(content);
         });
       }
     } else {
-      // LaTeX is currently OFF -> Toggle it ON
-      const bracketRegex = /\[((?:[^\[\]]|\[[^\[\]]*\])*)\]/g;
-      const hasBrackets = bracketRegex.test(fullText);
-      if (hasBrackets) {
-        bracketRegex.lastIndex = 0; // Reset regex index
-        // Convert [content] to inline $parsedContent$
-        result = fullText.replace(bracketRegex, function(match, content) {
-          return "$" + parseLatex(content) + "$";
-        });
-      } else {
-        // Wrap the entire parsed note in block LaTeX $$
-        result = "$$\n" + parseLatex(fullText) + "\n$$";
-      }
+      result = parseLatex(fullText);
     }
 
     return new ReturnObject({
       status: "success",
-      message: isLaTeXOn ? "Removed LaTeX formatting." : "Applied LaTeX formatting.",
+      message: "Applied LaTeX formatting.",
       payload: result
     });
   };

--- a/extensions-unofficial/latex/index.js
+++ b/extensions-unofficial/latex/index.js
@@ -1,0 +1,371 @@
+(function() {
+  const extensionName = "latex";
+
+  const extensionRoot = new Extension({
+    name: extensionName,
+    version: "1.0.0",
+    endpoints: [],
+    requiredAPIKeys: [],
+    author: "user",
+    category: "Formatting",
+    dataScope: "full"
+  });
+
+  const superscripts = {
+    '0': '⁰', '1': '¹', '2': '²', '3': '³', '4': '⁴', '5': '⁵', '6': '⁶', '7': '⁷', '8': '⁸', '9': '⁹',
+    '+': '⁺', '-': '⁻', '=': '⁼', '(': '⁽', ')': '⁾', 'n': 'ⁿ', 'i': 'ⁱ',
+    'a': 'ᵃ', 'b': 'ᵇ', 'c': 'ᶜ', 'd': 'ᵈ', 'e': 'ᵉ', 'f': 'ᶠ', 'g': 'ᵍ', 'h': 'ʰ', 'j': 'ʲ',
+    'k': 'ᵏ', 'l': 'ˡ', 'm': 'ᵐ', 'o': 'ᵒ', 'p': 'ᵖ', 'r': 'ʳ', 's': 'ˢ', 't': 'ᵗ', 'u': 'ᵘ',
+    'v': 'ᵛ', 'w': 'ʷ', 'x': 'ˣ', 'y': 'ʸ', 'z': 'ᶻ',
+    'A': 'ᴬ', 'B': 'ᴮ', 'D': 'ᴰ', 'E': 'ᴱ', 'G': 'ᴳ', 'H': 'ᴴ', 'I': 'ᴵ', 'J': 'ᴶ', 'K': 'ᴷ', 'L': 'ᴸ',
+    'M': 'ᴹ', 'N': 'ᴺ', 'O': 'ᴼ', 'P': 'ᴾ', 'R': 'ᴿ', 'T': 'ᵀ', 'U': 'ᵁ', 'W': 'ᵂ', 'X': 'ˣ', 'Y': 'ʸ'
+  };
+
+  const subscripts = {
+    '0': '₀', '1': '₁', '2': '₂', '3': '₃', '4': '₄', '5': '₅', '6': '₆', '7': '₇', '8': '₈', '9': '₉',
+    '+': '₊', '-': '₋', '=': '₌', '(': '₍', ')': '₎',
+    'a': 'ₐ', 'e': 'ₑ', 'h': 'ₕ', 'i': 'ᵢ', 'j': 'ⱼ', 'k': 'ₖ', 'l': 'ₗ', 'm': 'ₘ', 'n': 'ₙ', 'o': 'ₒ',
+    'p': 'ₚ', 'r': 'ᵣ', 's': 'ₛ', 't': 'ₜ', 'u': 'ᵤ', 'v': 'ᵥ', 'x': 'ₓ'
+  };
+
+  const unicodeMap = {
+    // Logic & Set Theory
+    "forall": "∀",
+    "exists": "∃",
+    "land": "∧",
+    "lor": "∨",
+    "neg": "¬",
+    "cap": "∩",
+    "cup": "∪",
+    "bigcap": "⋂",
+    "bigcup": "⋃",
+    "bigwedge": "⋀",
+    "bigvee": "⋁",
+    "in": "∈",
+    "notin": "∉",
+    "ni": "∋",
+    "empty": "∅",
+    "emptyset": "∅",
+    "subset": "⊂",
+    "supset": "⊃",
+    "subseteq": "⊆",
+    "supseteq": "⊇",
+    "impl": "⇒",
+    "implies": "⇒",
+    "iff": "⇔",
+    "to": "→",
+    "gets": "←",
+    "rightarrow": "→",
+    "leftarrow": "←",
+    "leftrightarrow": "↔",
+    "Rightarrow": "⇒",
+    "Leftarrow": "⇐",
+    "Leftrightarrow": "⇔",
+
+    // Operators & Relations
+    "sum": "∑",
+    "prod": "∏",
+    "coprod": "∐",
+    "int": "∫",
+    "iint": "∬",
+    "iiint": "∭",
+    "oint": "∮",
+    "partial": "∂",
+    "nabla": "∇",
+    "infty": "∞",
+    "approx": "≈",
+    "equiv": "≡",
+    "cong": "≅",
+    "sim": "∼",
+    "ne": "≠",
+    "neq": "≠",
+    "le": "≤",
+    "leq": "≤",
+    "ge": "≥",
+    "geq": "≥",
+    "pm": "±",
+    "mp": "∓",
+    "times": "×",
+    "div": "÷",
+    "propto": "∝",
+    "cdot": "·",
+    "bullet": "•",
+    "circ": "◦",
+    "ast": "∗",
+
+    // Greek Letters (Lowercase)
+    "alpha": "α",
+    "beta": "β",
+    "gamma": "γ",
+    "delta": "δ",
+    "epsilon": "ε",
+    "zeta": "ζ",
+    "eta": "η",
+    "theta": "θ",
+    "iota": "ι",
+    "kappa": "κ",
+    "lambda": "λ",
+    "mu": "μ",
+    "nu": "ν",
+    "xi": "ξ",
+    "pi": "π",
+    "rho": "ρ",
+    "sigma": "σ",
+    "tau": "τ",
+    "upsilon": "υ",
+    "phi": "φ",
+    "chi": "χ",
+    "psi": "ψ",
+    "omega": "ω",
+
+    // Greek Letters (Uppercase)
+    "Gamma": "Γ",
+    "Delta": "Δ",
+    "Theta": "Θ",
+    "Lambda": "Λ",
+    "Xi": "Ξ",
+    "Pi": "Π",
+    "Sigma": "Σ",
+    "Phi": "Φ",
+    "Psi": "Ψ",
+    "Omega": "Ω"
+  };
+
+  function convertSuperscript(str) {
+    return str.split('').map(c => superscripts[c] || c).join('');
+  }
+
+  function convertSubscript(str) {
+    return str.split('').map(c => subscripts[c] || c).join('');
+  }
+
+  const sortedKeys = Object.keys(unicodeMap).sort((a, b) => b.length - a.length);
+  const keywordRegex = new RegExp("\\\\(" + sortedKeys.join("|") + ")\\b", "g");
+
+  function parseLatex(text) {
+    if (!text) return "";
+
+    let result = text;
+
+    // 0. Replace summation/product limits with parentheses ranges
+    const operators = {
+      "sum": "∑",
+      "prod": "∏",
+      "coprod": "∐",
+      "bigcap": "⋂",
+      "bigcup": "⋃",
+      "bigwedge": "⋀",
+      "bigvee": "⋁"
+    };
+
+    const opKeys = Object.keys(operators).join("|");
+    const subSupBraces = new RegExp("\\\\(" + opKeys + ")_\\{([^{}]+)\\}\\^\\{([^{}]+)\\}", "g");
+    const supSubBraces = new RegExp("\\\\(" + opKeys + ")\\^\\{([^{}]+)\\}_\\{([^{}]+)\\}", "g");
+    const subBraces = new RegExp("\\\\(" + opKeys + ")_\\{([^{}]+)\\}", "g");
+    const supBraces = new RegExp("\\\\(" + opKeys + ")\\^\\{([^{}]+)\\}", "g");
+
+    const subSupSingle = new RegExp("\\\\(" + opKeys + ")_([0-9a-zA-Z])\\^([0-9a-zA-Z])", "g");
+    const supSubSingle = new RegExp("\\\\(" + opKeys + ")\\^([0-9a-zA-Z])_([0-9a-zA-Z])", "g");
+    const subSingle = new RegExp("\\\\(" + opKeys + ")_([0-9a-zA-Z])", "g");
+    const supSingle = new RegExp("\\\\(" + opKeys + ")\\^([0-9a-zA-Z])", "g");
+
+    // Replace both limits (braced)
+    result = result.replace(subSupBraces, function(match, op, sub, sup) {
+      return operators[op] + "(" + parseLatex(sub) + " → " + parseLatex(sup) + ")";
+    });
+    result = result.replace(supSubBraces, function(match, op, sup, sub) {
+      return operators[op] + "(" + parseLatex(sub) + " → " + parseLatex(sup) + ")";
+    });
+
+    // Replace both limits (single character)
+    result = result.replace(subSupSingle, function(match, op, sub, sup) {
+      return operators[op] + "(" + parseLatex(sub) + " → " + parseLatex(sup) + ")";
+    });
+    result = result.replace(supSubSingle, function(match, op, sup, sub) {
+      return operators[op] + "(" + parseLatex(sub) + " → " + parseLatex(sup) + ")";
+    });
+
+    // Replace single limits (braced)
+    result = result.replace(subBraces, function(match, op, sub) {
+      return operators[op] + "(" + parseLatex(sub) + ")";
+    });
+    result = result.replace(supBraces, function(match, op, sup) {
+      return operators[op] + "(→ " + parseLatex(sup) + ")";
+    });
+
+    // Replace single limits (single character)
+    result = result.replace(subSingle, function(match, op, sub) {
+      return operators[op] + "(" + parseLatex(sub) + ")";
+    });
+    result = result.replace(supSingle, function(match, op, sup) {
+      return operators[op] + "(→ " + parseLatex(sup) + ")";
+    });
+
+    // 1. Replace keywords
+    result = result.replace(keywordRegex, function(match, key) {
+      return unicodeMap[key] || match;
+    });
+
+    // 2. Replace fractions: \frac{a}{b} -> (a)/(b)
+    let fractionRegex = /\\frac\s*\{([^{}]+)\}\s*\{([^{}]+)\}/g;
+    while (fractionRegex.test(result)) {
+      result = result.replace(fractionRegex, "($1)/($2)");
+    }
+
+    // 3. Replace square roots: \sqrt{a} -> √a or √(a)
+    let sqrtRegex = /\\sqrt\s*\{([^{}]+)\}/g;
+    while (sqrtRegex.test(result)) {
+      result = result.replace(sqrtRegex, "√($1)");
+    }
+    result = result.replace(/\\sqrt\s*([0-9a-zA-Z\(\)])/g, "√$1");
+
+    // 4. Replace superscripts: x^{abc} -> xᵃᵇᶜ or x^2 -> x²
+    result = result.replace(/\^\{([^{}]+)\}/g, function(match, content) {
+      return convertSuperscript(content);
+    });
+    result = result.replace(/\^([0-9a-zA-Z+-=()])/g, function(match, content) {
+      return convertSuperscript(content);
+    });
+
+    // 5. Replace subscripts: x_{abc} -> xₐ♭꜀ or x_2 -> x₂
+    result = result.replace(/_\{([^{}]+)\}/g, function(match, content) {
+      return convertSubscript(content);
+    });
+    result = result.replace(/_([0-9a-zA-Z+-=()])/g, function(match, content) {
+      return convertSubscript(content);
+    });
+
+    // 6. Clean up LaTeX formatting syntax
+    result = result.replace(/\\(quad|qquad)/g, "  ");
+    result = result.replace(/\\[,;!]/g, " ");
+    result = result.replace(/\\(left|right)/g, "");
+
+    return result;
+  }
+
+  // Command 1: latex
+  const latex = new Command({
+    name: "latex",
+    parameters: [
+      new Parameter({
+        type: "string",
+        name: "expression",
+        helpText: "The math expression to format",
+        required: true
+      })
+    ],
+    type: "replaceLine",
+    helpText: "Translate a LaTeX math expression into Unicode characters",
+    tutorials: [
+      new TutorialCommand({
+        command: "latex(\\forall x \\exists \\delta)",
+        description: "Translates to ∀ ∃ δ"
+      })
+    ],
+    extension: extensionRoot
+  });
+
+  latex.execute = function(payload) {
+    let expression = "";
+    const fullText = payload.fullText || "";
+
+    // Extract the raw expression with backslashes from fullText to bypass escaping stripping
+    const match = fullText.match(/::latex\((.*?)\)/);
+    if (match) {
+      expression = match[1];
+    } else {
+      const [parsedParam] = this.getParsedParams(payload);
+      expression = parsedParam || "";
+    }
+
+    if (!expression) {
+      return new ReturnObject({
+        status: "error",
+        message: "Please provide a math expression."
+      });
+    }
+
+    const parsed = parseLatex(expression);
+
+    return new ReturnObject({
+      status: "success",
+      message: "Successfully formatted math expression.",
+      payload: parsed
+    });
+  };
+
+  // Command 2: latex_note
+  const latex_note = new Command({
+    name: "latex_note",
+    parameters: [],
+    type: "replaceAll",
+    helpText: "Auto-detect and toggle LaTeX formatting in the note",
+    tutorials: [
+      new TutorialCommand({
+        command: "latex_note",
+        description: "Toggles LaTeX formatting in the entire note"
+      })
+    ],
+    extension: extensionRoot
+  });
+
+  latex_note.execute = function(payload) {
+    const fullText = payload.fullText || "";
+
+    const hasDoubleDollar = fullText.includes("$$");
+    const hasSingleDollar = fullText.includes("$");
+    const isLaTeXOn = hasDoubleDollar || hasSingleDollar;
+
+    let result;
+    if (isLaTeXOn) {
+      // LaTeX is currently ON -> Toggle it OFF
+      const trimmed = fullText.trim();
+      const startsWithDollar = trimmed.startsWith("$$\n") || trimmed.startsWith("$$");
+      const endsWithDollar = trimmed.endsWith("\n$$") || trimmed.endsWith("$$");
+
+      if (startsWithDollar && endsWithDollar) {
+        // Unwrap block LaTeX note
+        let content = trimmed;
+        if (content.startsWith("$$\n")) {
+          content = content.substring(3);
+        } else if (content.startsWith("$$")) {
+          content = content.substring(2);
+        }
+
+        if (content.endsWith("\n$$")) {
+          content = content.substring(0, content.length - 3);
+        } else if (content.endsWith("$$")) {
+          content = content.substring(0, content.length - 2);
+        }
+        result = content;
+      } else {
+        // Convert block $$content$$ to [content]
+        let temp = fullText.replace(/\$\$(.*?)\$\$/gs, function(match, content) {
+          return "[" + content + "]";
+        });
+        // Convert inline $content$ to [content]
+        result = temp.replace(/\$([^$\n]+)\$/g, function(match, content) {
+          return "[" + content + "]";
+        });
+      }
+    } else {
+      // LaTeX is currently OFF -> Toggle it ON
+      const hasBrackets = /\[([^\]]+)\]/.test(fullText);
+      if (hasBrackets) {
+        // Convert [content] to inline $parsedContent$
+        result = fullText.replace(/\[([^\]]+)\]/g, function(match, content) {
+          return "$" + parseLatex(content) + "$";
+        });
+      } else {
+        // Wrap the entire parsed note in block LaTeX $$
+        result = "$$\n" + parseLatex(fullText) + "\n$$";
+      }
+    }
+
+    return new ReturnObject({
+      status: "success",
+      message: isLaTeXOn ? "Removed LaTeX formatting." : "Applied LaTeX formatting.",
+      payload: result
+    });
+  };
+})();

--- a/extensions-unofficial/latex/index.js
+++ b/extensions-unofficial/latex/index.js
@@ -3,7 +3,7 @@
 
   const extensionRoot = new Extension({
     name: extensionName,
-    version: "1.0.0",
+    version: "1.0.1",
     endpoints: [],
     requiredAPIKeys: [],
     author: "user",
@@ -269,11 +269,28 @@
     let expression = "";
     const fullText = payload.fullText || "";
 
-    // Extract the raw expression with backslashes from fullText to bypass escaping stripping
-    const match = fullText.match(/::latex\((.*?)\)/);
-    if (match) {
-      expression = match[1];
-    } else {
+    // Extract the raw expression with balanced parentheses counting
+    const cmdIndex = fullText.indexOf("::latex(");
+    if (cmdIndex !== -1) {
+      let depth = 1;
+      let i = cmdIndex + 8; // length of "::latex("
+      while (i < fullText.length && depth > 0) {
+        const char = fullText[i];
+        if (char === '(') {
+          depth++;
+        } else if (char === ')') {
+          depth--;
+        }
+        
+        if (depth > 0) {
+          expression += char;
+        }
+        i++;
+      }
+    }
+
+    // Fallback if not found in fullText or parsing failed
+    if (!expression) {
       const [parsedParam] = this.getParsedParams(payload);
       expression = parsedParam || "";
     }
@@ -350,10 +367,12 @@
       }
     } else {
       // LaTeX is currently OFF -> Toggle it ON
-      const hasBrackets = /\[([^\]]+)\]/.test(fullText);
+      const bracketRegex = /\[((?:[^\[\]]|\[[^\[\]]*\])*)\]/g;
+      const hasBrackets = bracketRegex.test(fullText);
       if (hasBrackets) {
+        bracketRegex.lastIndex = 0; // Reset regex index
         // Convert [content] to inline $parsedContent$
-        result = fullText.replace(/\[([^\]]+)\]/g, function(match, content) {
+        result = fullText.replace(bracketRegex, function(match, content) {
           return "$" + parseLatex(content) + "$";
         });
       } else {

--- a/extensions-unofficial/latex/index.test.js
+++ b/extensions-unofficial/latex/index.test.js
@@ -1,0 +1,204 @@
+// Test file for latex extension
+// This file tests both the extension metadata and command execution
+
+var fs = require('fs');
+var path = require('path');
+
+// Mock test framework functions
+function describe(name, fn) {
+  console.log("\n" + name);
+  fn();
+}
+
+// Custom it function
+function it(name, fn) {
+  try {
+    fn();
+    console.log("  ✓ " + name);
+  } catch (e) {
+    console.log("  ✗ " + name);
+    console.log("    Error: " + e.message);
+  }
+}
+
+// Custom expect function
+function expect(actual) {
+  return {
+    toBe: function(expected) {
+      if (actual !== expected) {
+        throw new Error("Expected '" + expected + "' but got '" + actual + "'");
+      }
+    },
+    toContain: function(expected) {
+      if (actual.indexOf(expected) === -1) {
+        throw new Error("Expected '" + actual + "' to contain '" + expected + "'");
+      }
+    },
+    toBeDefined: function() {
+      if (actual === undefined || actual === null) {
+        throw new Error("Expected value to be defined");
+      }
+    },
+    toBeArray: function() {
+      if (!Array.isArray(actual)) {
+        throw new Error("Expected " + actual + " to be an array");
+      }
+    },
+    toBeGreaterThanOrEqual: function(expected) {
+      if (actual < expected) {
+        throw new Error("Expected " + actual + " to be >= " + expected);
+      }
+    }
+  };
+}
+
+// Load and parse extension.json
+var metadataPath = path.join(__dirname, 'extension.json');
+var metadataContent = fs.readFileSync(metadataPath, 'utf8');
+var metadata = JSON.parse(metadataContent);
+
+// Tests for extension metadata
+describe("LaTeX Extension - Metadata Validation", function() {
+
+  it("should have required name field", function() {
+    expect(metadata.name).toBeDefined();
+    expect(metadata.name).toBe("latex");
+  });
+
+  it("should have required version field", function() {
+    expect(metadata.version).toBeDefined();
+    expect(metadata.version).toBe("1.0.0");
+  });
+
+  it("should have required category field", function() {
+    expect(metadata.category).toBeDefined();
+    expect(metadata.category).toBe("Formatting");
+  });
+
+  it("should have required dataScope field", function() {
+    expect(metadata.dataScope).toBeDefined();
+    expect(metadata.dataScope).toBe("full");
+  });
+
+  it("should have the expected commands", function() {
+    expect(metadata.commands).toBeDefined();
+    expect(metadata.commands).toBeArray();
+    expect(metadata.commands.length).toBe(2);
+    expect(metadata.commands[0].name).toBe("latex");
+    expect(metadata.commands[1].name).toBe("latex_note");
+  });
+});
+
+describe("LaTeX Extension - Command Execution Tests", function() {
+
+  describe("latex command", function() {
+    it("should format symbols with backslashes and ignore those without", function() {
+      var payload = {
+        parameters: ["forall without backslash"],
+        fullText: "::latex(\\forall x \\exists \\land \\bigwedge \\delta and forall without backslash)",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("∀ x ∃ ∧ ⋀ δ and forall without backslash");
+    });
+
+    it("should format superscripts and subscripts", function() {
+      var payload = {
+        parameters: ["x^2 + y_i = z_{n+1}"],
+        fullText: "",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("x² + yᵢ = zₙ₊₁");
+    });
+
+    it("should format fractions and square roots", function() {
+      var payload = {
+        parameters: ["\\frac{a}{b} + \\sqrt{x} + \\sqrt{16}"],
+        fullText: "",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("(a)/(b) + √(x) + √(16)");
+    });
+
+    it("should format summation and product ranges with parentheses", function() {
+      var payload = {
+        parameters: ["\\sum_{n=0}^{10} + \\sum_{i=1}^{\\infty} + \\sum_{i=1} + \\prod_{n=1}^{5} + \\sum"],
+        fullText: "",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("∑(n=0 → 10) + ∑(i=1 → ∞) + ∑(i=1) + ∏(n=1 → 5) + ∑");
+    });
+  });
+
+  describe("latex_note command", function() {
+    it("should replace bracketed expressions and parse them (Toggle On)", function() {
+      var payload = {
+        parameters: [],
+        fullText: "The result is [\\forall x \\exists \\land \\bigwedge \\delta].",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("The result is $∀ x ∃ ∧ ⋀ δ$.");
+    });
+
+    it("should wrap entire note in block delimiters and parse it when no brackets are present (Toggle On)", function() {
+      var payload = {
+        parameters: [],
+        fullText: "x^2 + y_i",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("$$\nx² + yᵢ\n$$");
+    });
+
+    it("should unwrap text if it is already block-wrapped (Toggle Off)", function() {
+      var payload = {
+        parameters: [],
+        fullText: "$$\nx² + yᵢ\n$$",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("x² + yᵢ");
+    });
+
+    it("should convert inline LaTeX back to brackets (Toggle Off)", function() {
+      var payload = {
+        parameters: [],
+        fullText: "The result is $∀ x ∃ ∧ ⋀ δ$.",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("The result is [∀ x ∃ ∧ ⋀ δ].");
+    });
+  });
+});
+
+console.log("Running LaTeX Extension Tests...");
+console.log("=========================================");

--- a/extensions-unofficial/latex/index.test.js
+++ b/extensions-unofficial/latex/index.test.js
@@ -67,7 +67,7 @@ describe("LaTeX Extension - Metadata Validation", function() {
 
   it("should have required version field", function() {
     expect(metadata.version).toBeDefined();
-    expect(metadata.version).toBe("1.0.1");
+    expect(metadata.version).toBe("1.0.2");
   });
 
   it("should have required category field", function() {
@@ -159,7 +159,7 @@ describe("LaTeX Extension - Command Execution Tests", function() {
   });
 
   describe("latex_note command", function() {
-    it("should replace bracketed expressions and parse them (Toggle On)", function() {
+    it("should replace and parse bracketed expressions and strip the brackets", function() {
       var payload = {
         parameters: [],
         fullText: "The result is [\\forall x \\exists \\land \\bigwedge \\delta].",
@@ -169,10 +169,10 @@ describe("LaTeX Extension - Command Execution Tests", function() {
 
       var result = latex_note.execute(payload);
       expect(result.status).toBe("success");
-      expect(result.payload).toBe("The result is $∀ x ∃ ∧ ⋀ δ$.");
+      expect(result.payload).toBe("The result is ∀ x ∃ ∧ ⋀ δ.");
     });
 
-    it("should format nested brackets in latex_note command (Toggle On)", function() {
+    it("should format nested brackets and strip outer brackets", function() {
       var payload = {
         parameters: [],
         fullText: "The equation is [A \\cup [B \\cap C]].",
@@ -182,10 +182,10 @@ describe("LaTeX Extension - Command Execution Tests", function() {
 
       var result = latex_note.execute(payload);
       expect(result.status).toBe("success");
-      expect(result.payload).toBe("The equation is $A ∪ [B ∩ C]$.");
+      expect(result.payload).toBe("The equation is A ∪ [B ∩ C].");
     });
 
-    it("should wrap entire note in block delimiters and parse it when no brackets are present (Toggle On)", function() {
+    it("should parse the entire note when no brackets/delimiters are present", function() {
       var payload = {
         parameters: [],
         fullText: "x^2 + y_i",
@@ -195,33 +195,33 @@ describe("LaTeX Extension - Command Execution Tests", function() {
 
       var result = latex_note.execute(payload);
       expect(result.status).toBe("success");
-      expect(result.payload).toBe("$$\nx² + yᵢ\n$$");
-    });
-
-    it("should unwrap text if it is already block-wrapped (Toggle Off)", function() {
-      var payload = {
-        parameters: [],
-        fullText: "$$\nx² + yᵢ\n$$",
-        userSettings: {},
-        preferences: {}
-      };
-
-      var result = latex_note.execute(payload);
-      expect(result.status).toBe("success");
       expect(result.payload).toBe("x² + yᵢ");
     });
 
-    it("should convert inline LaTeX back to brackets (Toggle Off)", function() {
+    it("should parse and strip block-wrapped $$ delimiters", function() {
       var payload = {
         parameters: [],
-        fullText: "The result is $∀ x ∃ ∧ ⋀ δ$.",
+        fullText: "$$\nx^2 + y_i\n$$",
         userSettings: {},
         preferences: {}
       };
 
       var result = latex_note.execute(payload);
       expect(result.status).toBe("success");
-      expect(result.payload).toBe("The result is [∀ x ∃ ∧ ⋀ δ].");
+      expect(result.payload).toBe("\nx² + yᵢ\n");
+    });
+
+    it("should parse and strip inline $ delimiters", function() {
+      var payload = {
+        parameters: [],
+        fullText: "The result is $\\forall x \\exists \\land \\bigwedge \\delta$.",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("The result is ∀ x ∃ ∧ ⋀ δ.");
     });
   });
 });

--- a/extensions-unofficial/latex/index.test.js
+++ b/extensions-unofficial/latex/index.test.js
@@ -67,7 +67,7 @@ describe("LaTeX Extension - Metadata Validation", function() {
 
   it("should have required version field", function() {
     expect(metadata.version).toBeDefined();
-    expect(metadata.version).toBe("1.0.0");
+    expect(metadata.version).toBe("1.0.1");
   });
 
   it("should have required category field", function() {
@@ -143,6 +143,19 @@ describe("LaTeX Extension - Command Execution Tests", function() {
       expect(result.status).toBe("success");
       expect(result.payload).toBe("∑(n=0 → 10) + ∑(i=1 → ∞) + ∑(i=1) + ∏(n=1 → 5) + ∑");
     });
+
+    it("should handle nested parentheses in latex command without cutoff", function() {
+      var payload = {
+        parameters: ["f(x) = y"],
+        fullText: "::latex(f(x) = y)",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("f(x) = y");
+    });
   });
 
   describe("latex_note command", function() {
@@ -157,6 +170,19 @@ describe("LaTeX Extension - Command Execution Tests", function() {
       var result = latex_note.execute(payload);
       expect(result.status).toBe("success");
       expect(result.payload).toBe("The result is $∀ x ∃ ∧ ⋀ δ$.");
+    });
+
+    it("should format nested brackets in latex_note command (Toggle On)", function() {
+      var payload = {
+        parameters: [],
+        fullText: "The equation is [A \\cup [B \\cap C]].",
+        userSettings: {},
+        preferences: {}
+      };
+
+      var result = latex_note.execute(payload);
+      expect(result.status).toBe("success");
+      expect(result.payload).toBe("The equation is $A ∪ [B ∩ C]$.");
     });
 
     it("should wrap entire note in block delimiters and parse it when no brackets are present (Toggle On)", function() {


### PR DESCRIPTION
::latex(expression)
Translates a single LaTeX math expression into Unicode on the current line.

e.g. ::latex(\forall x \exists \delta) → ∀ x ∃ δ

::latex_note
Formats LaTeX math across the entire note.